### PR TITLE
fix greedy matching for fallback

### DIFF
--- a/src/main/scala/tv/teads/wiremock/extension/JsonExtractor.scala
+++ b/src/main/scala/tv/teads/wiremock/extension/JsonExtractor.scala
@@ -20,7 +20,7 @@ class JsonExtractor extends ResponseTransformer {
 
   override val applyGlobally: Boolean = false
 
-  private val fallbackRegex: Regex = """(?:\§(.+))?""".r
+  private val fallbackRegex: Regex = """(?:\§(.+?))?""".r
   private val jsonPathRegex: Regex = """(\$\.[ ='a-zA-Z0-9\@\.\[\]\*\,\:\?\(\)\&\|\<\>]*)""".r
   private val pattern: Regex = ("""\$\{""" + jsonPathRegex + fallbackRegex + """\}""").r
 

--- a/src/test/scala/tv/teads/wiremock/extension/JsonExtractorSpec.scala
+++ b/src/test/scala/tv/teads/wiremock/extension/JsonExtractorSpec.scala
@@ -25,7 +25,8 @@ class JsonExtractorSpec extends ExtensionSpec {
     ("mixed found/not found", """{"single":"value"}""", s"$${$$.undefined} $${$$.single}", s"$${$$.undefined} value"),
     ("nested replacements", s"""{"single":"value", "path":"$$.single"}""", s"$${$${$$.path}}", "value"),
     ("path as fallback", """{"single":"value"}""", s"$${$$.undefined§$${$$.single}}", "value"),
-    ("multi fallbacks", "{}", s"$${$$.undefined§$${$$.undefined§value}}", "value")
+    ("multi fallbacks", "{}", s"$${$$.undefined§$${$$.undefined§value}}", "value"),
+    ("complex template", "{}", s"""{"one":"value", "another":"$${$$.undefined§0}", "last": "one"}""", """{"one":"value", "another":"0", "last": "one"}""")
   )
 
   "JsonExtractor" should "replace JSONPath in response body" in {


### PR DESCRIPTION
Fallback should be lazy, and match its end at the first }. If not
it will try to read the output template as far as possible.
