### PR TITLE
Handle filtering on all primitive types in find-first-in-array

### DIFF
--- a/src/main/scala/tv/teads/wiremock/extension/FreeMarkerRenderer.scala
+++ b/src/main/scala/tv/teads/wiremock/extension/FreeMarkerRenderer.scala
@@ -128,7 +128,7 @@ class FreeMarkerRenderer extends ResponseDefinitionTransformer {
           val (filteredChildPath, filteredChildValue) = extractPathAndValueFromCondition(filteredChildCondition)
 
           arrayNode.elements().asScala
-            .find(findChildNode(_, filteredChildPath).textValue() == filteredChildValue)
+            .find(findChildNode(_, filteredChildPath).asText() == filteredChildValue)
             .map(findChildNode(_, wantedChildPath)) match {
               case Some(wantedNode) ⇒ json2template(wrapper, wantedNode)
               case _                ⇒ wrapper.wrap(null)

--- a/src/test/scala/tv/teads/wiremock/extension/FreeMarkerRendererSpec.scala
+++ b/src/test/scala/tv/teads/wiremock/extension/FreeMarkerRendererSpec.scala
@@ -20,6 +20,8 @@ class FreeMarkerRendererSpec extends ExtensionSpec {
     ("array glue", """{"array":["1","2"]}""", s"""$${$$.array?join(",")}""", """1,2"""),
     ("array find first (simple case)", """{"cheap-cars":[{"details":{"price":15.5, "brand":"toyota"}},{"details":{"price":10,"brand":"lexus"}}]}""",
       s"""$${findFirstInArray('cheap-cars', 'details.brand == toyota', 'details.price')?c}""", """15.5"""),
+    ("array find first (simple case 2)", """{"cheap-cars":[{"details":{"price":15.5, "brand":"toyota"}},{"details":{"price":10,"brand":"lexus"}}]}""",
+      s"""$${findFirstInArray('cheap-cars', 'details.price == 15.5', 'details.brand')}""", """toyota"""),
     ("array find first (missing data)", """{"cheap-cars":[{"details":{"price":15.5, "brand":"toyota"}},{"details":{"price":10,"brand":"lexus"}}]}""",
       s"""$${(findFirstInArray('cheap-cars', 'details.brand == unknown', 'details.price')?c)!100}""", """100"""),
     ("array find first (array filter in wanted node)", """{"cheap-cars":[{"details":{"price":15.5,"brand":"toyota","customers":[{"name":"Alix","age":44},{"name":"Valentin","age":90}]}},{"details":{"price":10,"brand":"lexus","deals":[{"name":"Tristan","age":32}]}}]}""",


### PR DESCRIPTION
This PR aims to handle filtering on all primitive types for `find-first-in-array` usage

Example : 

```json
{
  "cheap-cars": [
    {
      "details": {
        "price": 15.5,
        "brand": "toyota"
      }
    },
    {
      "details": {
        "price": 10,
        "brand": "lexus"
      }
    }
  ]
}
```

We want to be able to do filtering on price as such :

`findFirstInArray('cheap-cars', 'details.price == 15.5', 'details.brand')`  , meaning find the cheap-car's brand name whose price is `15.5` 

This is currently not working as the filtering node has to be a json textNode.
This PR fixes it.